### PR TITLE
feat(rabbitmq): enable automatic RmqError to anyhow::Error conversion…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "foxtive"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/foxtive/CHANGELOG.md
+++ b/foxtive/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Foxtive Changelog
 Foxtive changelog file 
 
+### 0.26.2 (2026-05-14)
+* feat(rabbitmq): enable automatic RmqError to anyhow::Error conversion for seamless interoperability
+
 ### 0.26.1 (2026-05-14)
 * feat(rabbitmq): add Msg.delivery_tag() to easily extract message delivery tag
 

--- a/foxtive/Cargo.toml
+++ b/foxtive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foxtive"
-version = "0.26.1"
+version = "0.26.2"
 edition = "2024"
 license = "MIT"
 description = "Foxtive Framework"

--- a/foxtive/src/rabbitmq/error.rs
+++ b/foxtive/src/rabbitmq/error.rs
@@ -253,6 +253,97 @@ mod tests {
     }
 
     #[test]
+    fn test_rmqerror_to_anyhow_conversion() {
+        // Verify RmqError can be converted to anyhow::Error automatically
+        let rmq_err = RmqError::timeout("test_op", Duration::from_secs(5));
+        
+        // This should compile thanks to anyhow's blanket From implementation
+        let anyhow_err: anyhow::Error = rmq_err.into();
+        
+        assert!(anyhow_err.to_string().contains("test_op"));
+        assert!(anyhow_err.to_string().contains("5s"));
+    }
+
+    #[test]
+    fn test_rmqerror_variants_convert_to_anyhow() {
+        // Test that various RmqError variants convert properly
+        
+        // Test simple variants
+        let err1 = RmqError::Generic("test error".to_string());
+        let anyhow_err1: anyhow::Error = err1.into();
+        assert!(!anyhow_err1.to_string().is_empty());
+        assert!(anyhow_err1.downcast_ref::<RmqError>().is_some());
+        
+        let err2 = RmqError::ShutdownRequested;
+        let anyhow_err2: anyhow::Error = err2.into();
+        assert!(anyhow_err2.to_string().contains("Shutdown"));
+        
+        let err3 = RmqError::health_check_failed("pool exhausted");
+        let anyhow_err3: anyhow::Error = err3.into();
+        assert!(anyhow_err3.to_string().contains("pool exhausted"));
+        
+        let err4 = RmqError::channel_error("Closed", 1);
+        let anyhow_err4: anyhow::Error = err4.into();
+        assert!(anyhow_err4.to_string().contains("Closed"));
+        
+        let err5 = RmqError::stream_terminated("queue", "tag");
+        let anyhow_err5: anyhow::Error = err5.into();
+        assert!(anyhow_err5.to_string().contains("queue"));
+        
+        let err6 = RmqError::Configuration {
+            message: "bad config".to_string(),
+        };
+        let anyhow_err6: anyhow::Error = err6.into();
+        assert!(anyhow_err6.to_string().contains("bad config"));
+        
+        let err7 = RmqError::ReconnectionFailed { attempts: 3 };
+        let anyhow_err7: anyhow::Error = err7.into();
+        assert!(anyhow_err7.to_string().contains("3"));
+    }
+
+    #[test]
+    fn test_question_mark_operator_conversion() {
+        // Simulate a function that returns AppResult but calls RmqResult functions
+        fn simulate_app_result() -> anyhow::Result<()> {
+            // This simulates using ? with RmqResult in an AppResult context
+            let result: RmqResult<()> = Err(RmqError::timeout("op", Duration::from_secs(1)));
+            result?; // Should compile and convert automatically
+            Ok(())
+        }
+
+        let err = simulate_app_result().unwrap_err();
+        assert!(err.to_string().contains("timed out"));
+        
+        // Verify we can inspect the original error
+        let rmq_err = err.downcast_ref::<RmqError>().unwrap();
+        match rmq_err {
+            RmqError::Timeout { operation, .. } => {
+                assert_eq!(operation, "op");
+            }
+            _ => panic!("Expected Timeout variant"),
+        }
+    }
+
+    #[test]
+    fn test_nested_error_conversion() {
+        // Test that nested errors preserve information through conversion
+        let json_err = serde_json::from_str::<String>("invalid").unwrap_err();
+        let rmq_err = RmqError::Serialization(json_err);
+        let anyhow_err: anyhow::Error = rmq_err.into();
+        
+        // The error message should contain serialization info
+        assert!(anyhow_err.to_string().contains("Serialization error"));
+        
+        // Can still downcast to RmqError
+        let downcast = anyhow_err.downcast_ref::<RmqError>();
+        assert!(downcast.is_some());
+        match downcast.unwrap() {
+            RmqError::Serialization(_) => {} // Success
+            _ => panic!("Expected Serialization variant"),
+        }
+    }
+
+    #[test]
     fn test_error_debug_trait() {
         let err = RmqError::Generic("test error".to_string());
         let debug_msg = format!("{:?}", err);


### PR DESCRIPTION
… for seamless interoperability