### PR TITLE
feat(rabbitmq): add AppError variant to RmqError for preserving anyho…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "foxtive"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/foxtive/CHANGELOG.md
+++ b/foxtive/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Foxtive Changelog
 Foxtive changelog file 
 
+### 0.26.3 (2026-05-14)
+* feat(rabbitmq): add AppError variant to RmqError for preserving anyhow::Error types
+* feat(rabbitmq): add IntoRmqError trait for ergonomic error conversion in consume closures
+* feat(rabbitmq): enable bidirectional downcasting between RmqError and anyhow::Error
+* fix(rabbitmq): preserve error type information instead of converting to strings
+* test(rabbitmq): add tests for error preservation and bidirectional conversion
+
 ### 0.26.2 (2026-05-14)
 * feat(rabbitmq): enable automatic RmqError to anyhow::Error conversion for seamless interoperability
 

--- a/foxtive/Cargo.toml
+++ b/foxtive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foxtive"
-version = "0.26.2"
+version = "0.26.3"
 edition = "2024"
 license = "MIT"
 description = "Foxtive Framework"

--- a/foxtive/src/lib.rs
+++ b/foxtive/src/lib.rs
@@ -40,7 +40,7 @@ pub mod prelude {
     pub use crate::enums::AppMessage;
     pub use crate::ext::app_state::AppStateExt;
     #[cfg(feature = "rabbitmq")]
-    pub use crate::rabbitmq::{RabbitMQ, RmqError, RmqResult};
+    pub use crate::rabbitmq::{IntoRmqError, RabbitMQ, RmqError, RmqResult};
     #[cfg(feature = "redis")]
     pub use crate::redis::Redis;
     pub use crate::results::{AppResult, app_result::IntoAppResult};

--- a/foxtive/src/rabbitmq/error.rs
+++ b/foxtive/src/rabbitmq/error.rs
@@ -4,10 +4,10 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum RmqError {
     #[error("Connection error: {0}")]
-    Connection(#[from] lapin::Error),
+    Connection(lapin::Error),
 
     #[error("Pool error: {0}")]
-    Pool(#[from] deadpool_lapin::PoolError),
+    Pool(deadpool_lapin::PoolError),
 
     #[error("Stream terminated unexpectedly for queue '{queue}' with tag '{tag}'")]
     StreamTerminated { queue: String, tag: String },
@@ -58,13 +58,16 @@ pub enum RmqError {
     Configuration { message: String },
 
     #[error("Serialization error: {0}")]
-    Serialization(#[from] serde_json::Error),
+    Serialization(serde_json::Error),
 
     #[error("UTF-8 conversion error: {0}")]
-    Utf8Error(#[from] std::str::Utf8Error),
+    Utf8Error(std::str::Utf8Error),
 
     #[error("Generic error: {0}")]
     Generic(String),
+
+    #[error("Wrapped application error: {0}")]
+    AppError(#[from] anyhow::Error),
 }
 
 impl RmqError {
@@ -152,6 +155,42 @@ impl RmqError {
 
 /// Result type alias for RabbitMQ operations
 pub type RmqResult<T> = Result<T, RmqError>;
+
+// Manual From implementations (can only have one #[from] per enum)
+impl From<lapin::Error> for RmqError {
+    fn from(err: lapin::Error) -> Self {
+        Self::Connection(err)
+    }
+}
+
+impl From<deadpool_lapin::PoolError> for RmqError {
+    fn from(err: deadpool_lapin::PoolError) -> Self {
+        Self::Pool(err)
+    }
+}
+
+impl From<serde_json::Error> for RmqError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Serialization(err)
+    }
+}
+
+impl From<std::str::Utf8Error> for RmqError {
+    fn from(err: std::str::Utf8Error) -> Self {
+        Self::Utf8Error(err)
+    }
+}
+
+/// Helper trait to convert anyhow::Error to RmqError
+pub trait IntoRmqError<T> {
+    fn into_rmq(self) -> RmqResult<T>;
+}
+
+impl<T> IntoRmqError<T> for Result<T, anyhow::Error> {
+    fn into_rmq(self) -> RmqResult<T> {
+        self.map_err(RmqError::from)
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -340,6 +379,45 @@ mod tests {
         match downcast.unwrap() {
             RmqError::Serialization(_) => {} // Success
             _ => panic!("Expected Serialization variant"),
+        }
+    }
+
+    #[test]
+    fn test_anyhow_to_rmqerror_preserves_type() {
+        // Create an AppResult error
+        let app_err: anyhow::Error = anyhow::anyhow!("application error");
+        
+        // Convert to RmqError using IntoRmqError trait
+        let result: RmqResult<()> = Err(app_err).into_rmq();
+        
+        // Verify it's wrapped as AppError variant
+        match result.unwrap_err() {
+            RmqError::AppError(err) => {
+                assert_eq!(err.to_string(), "application error");
+                
+                // Can downcast back to original error type if needed
+                // (though in this case it's just a string)
+            }
+            other => panic!("Expected AppError variant, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_bidirectional_conversion() {
+        // Test RmqError -> anyhow::Error -> RmqError preserves the error
+        let original = RmqError::timeout("test_op", Duration::from_secs(5));
+        
+        // Convert to anyhow
+        let anyhow_err: anyhow::Error = original.into();
+        
+        // Verify we can downcast back to RmqError
+        let recovered = anyhow_err.downcast_ref::<RmqError>().unwrap();
+        match recovered {
+            RmqError::Timeout { operation, timeout } => {
+                assert_eq!(operation, "test_op");
+                assert_eq!(timeout, &Duration::from_secs(5));
+            }
+            _ => panic!("Expected Timeout variant"),
         }
     }
 

--- a/foxtive/src/rabbitmq/mod.rs
+++ b/foxtive/src/rabbitmq/mod.rs
@@ -17,7 +17,7 @@ pub use {
     lapin::{Channel, ChannelState, ExchangeKind, options::*},
 };
 
-pub use crate::rabbitmq::error::{RmqError, RmqResult};
+pub use crate::rabbitmq::error::{IntoRmqError, RmqError, RmqResult};
 
 use crate::FOXTIVE;
 use crate::prelude::AppStateExt;


### PR DESCRIPTION
…w::Error types

* feat(rabbitmq): add IntoRmqError trait for ergonomic error conversion in consume closures
* feat(rabbitmq): enable bidirectional downcasting between RmqError and anyhow::Error
* fix(rabbitmq): preserve error type information instead of converting to strings
* test(rabbitmq): add tests for error preservation and bidirectional conversion