### PR TITLE
feat(redis): add comprehensive Redis command support with 70+ new methods covering string, hash, list, set, sorted set, key, and server operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,9 +131,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -627,7 +627,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "inout",
 ]
 
@@ -825,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -938,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1138,7 +1138,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid 0.9.6",
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "foxtive"
-version = "0.26.3"
+version = "0.26.4"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -1669,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -2537,9 +2537,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2598,9 +2598,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2629,9 +2629,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -4296,9 +4296,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",

--- a/foxtive/CHANGELOG.md
+++ b/foxtive/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Foxtive Changelog
 Foxtive changelog file 
 
+### 0.26.4 (2026-05-19)
+* feat(redis): add comprehensive Redis command support with 70+ new methods covering string, hash, list, set, sorted set, key, and server operations
+* feat(redis): use redis crate's AsyncCommands trait methods for type-safe API stability instead of raw commands
+* feat(redis): add string operations: getset, getrange, setrange, append, incr, decr, set_ex, pset_ex, set_nx, get_del, rename, rename_nx, unlink, strlen
+* feat(redis): add hash operations: hget, hmget, hdel, hset, hset_nx, hexists, hkeys, hvals, hgetall, hlen, hincr
+* feat(redis): add list operations: llen, lindex, linsert_before, linsert_after, lpush, ltrim, lset
+* feat(redis): add set operations: scard, sismember, smembers, srem, srandmember
+* feat(redis): add sorted set operations: zcard, zcount, zincr, zscore, zrank, zrem
+* feat(redis): add key operations: exists, expire, expire_at, pexpire, persist, ttl, pttl
+* feat(redis): add server operations: ping, dbsize
+* refactor(redis): ensure API stability by using typed AsyncCommands trait methods to prevent breakage on redis crate updates
+
 ### 0.26.3 (2026-05-14)
 * feat(rabbitmq): add AppError variant to RmqError for preserving anyhow::Error types
 * feat(rabbitmq): add IntoRmqError trait for ergonomic error conversion in consume closures

--- a/foxtive/Cargo.toml
+++ b/foxtive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foxtive"
-version = "0.26.3"
+version = "0.26.4"
 edition = "2024"
 license = "MIT"
 description = "Foxtive Framework"

--- a/foxtive/src/rabbitmq/mod.rs
+++ b/foxtive/src/rabbitmq/mod.rs
@@ -1,7 +1,7 @@
 use futures_util::StreamExt;
 use futures_util::future::BoxFuture;
 use lapin::types::FieldTable;
-use lapin::{BasicProperties, ConnectionState};
+use lapin::{BasicProperties, Channel, ConnectionState};
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
@@ -14,7 +14,7 @@ use tracing::{debug, error, info, warn};
 pub use {
     lapin::message::{Delivery, DeliveryResult},
     lapin::types::ReplyCode,
-    lapin::{Channel, ChannelState, ExchangeKind, options::*},
+    lapin::{ChannelState, ExchangeKind, options::*},
 };
 
 pub use crate::rabbitmq::error::{IntoRmqError, RmqError, RmqResult};

--- a/foxtive/src/redis/mod.rs
+++ b/foxtive/src/redis/mod.rs
@@ -6,6 +6,7 @@ use anyhow::Error;
 use futures_util::StreamExt;
 use redis::{AsyncCommands, FromRedisValue, ToRedisArgs, ToSingleRedisArg};
 use serde::Serialize;
+use std::collections::HashMap;
 use std::future::Future;
 use std::num::{NonZeroU64, NonZeroUsize};
 use std::time::Duration;
@@ -295,5 +296,506 @@ impl Redis {
     pub async fn keys_by_pattern(&self, pattern: &str) -> AppResult<Vec<String>> {
         let mut conn = self.redis().await?;
         conn.keys(pattern).await.into_app_result()
+    }
+
+    // String Operations
+
+    /// Get the value of a key and set its old value.
+    pub async fn getset<K: ToSingleRedisArg + Send + Sync, V: FromRedisValue>(
+        &self,
+        key: K,
+        value: K,
+    ) -> AppResult<Option<V>> {
+        let mut conn = self.redis().await?;
+        conn.getset(key, value).await.into_app_result()
+    }
+
+    /// Get a range of bytes/substring from the value of a key.
+    pub async fn getrange<K: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        from: isize,
+        to: isize,
+    ) -> AppResult<String> {
+        let mut conn = self.redis().await?;
+        conn.getrange(key, from, to).await.into_app_result()
+    }
+
+    /// Overwrite the part of the value stored in key at the specified offset.
+    pub async fn setrange<K: ToSingleRedisArg + Send + Sync, V: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        offset: isize,
+        value: V,
+    ) -> AppResult<usize> {
+        let mut conn = self.redis().await?;
+        conn.setrange(key, offset, value).await.into_app_result()
+    }
+
+    /// Append a value to a key.
+    pub async fn append<K: ToSingleRedisArg + Send + Sync, V: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        value: V,
+    ) -> AppResult<usize> {
+        let mut conn = self.redis().await?;
+        conn.append(key, value).await.into_app_result()
+    }
+
+    /// Increment the numeric value of a key by the given amount.
+    pub async fn incr<K: ToSingleRedisArg + Send + Sync, V: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        delta: V,
+    ) -> AppResult<isize> {
+        let mut conn = self.redis().await?;
+        conn.incr(key, delta).await.into_app_result()
+    }
+
+    /// Decrement the numeric value of a key by the given amount.
+    pub async fn decr<K: ToSingleRedisArg + Send + Sync, V: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        delta: V,
+    ) -> AppResult<isize> {
+        let mut conn = self.redis().await?;
+        conn.decr(key, delta).await.into_app_result()
+    }
+
+    /// Set the string value of a key with expiration in seconds.
+    pub async fn set_ex<K: ToSingleRedisArg + Send + Sync, V: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        value: V,
+        seconds: u64,
+    ) -> AppResult<()> {
+        let mut conn = self.redis().await?;
+        conn.set_ex(key, value, seconds).await.into_app_result()
+    }
+
+    /// Set the string value of a key with expiration in milliseconds.
+    pub async fn pset_ex<K: ToSingleRedisArg + Send + Sync, V: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        value: V,
+        milliseconds: u64,
+    ) -> AppResult<()> {
+        let mut conn = self.redis().await?;
+        conn.pset_ex(key, value, milliseconds).await.into_app_result()
+    }
+
+    /// Set the value of a key, only if the key does not exist.
+    pub async fn set_nx<K: ToSingleRedisArg + Send + Sync, V: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        value: V,
+    ) -> AppResult<bool> {
+        let mut conn = self.redis().await?;
+        conn.set_nx(key, value).await.into_app_result()
+    }
+
+    /// Get the value of a key and delete it.
+    pub async fn get_del<K: ToSingleRedisArg + Send + Sync, V: FromRedisValue>(
+        &self,
+        key: K,
+    ) -> AppResult<Option<V>> {
+        let mut conn = self.redis().await?;
+        conn.get_del(key).await.into_app_result()
+    }
+
+    /// Rename a key.
+    pub async fn rename<K: ToSingleRedisArg + Send + Sync, N: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        new_key: N,
+    ) -> AppResult<()> {
+        let mut conn = self.redis().await?;
+        conn.rename(key, new_key).await.into_app_result()
+    }
+
+    /// Rename a key, only if the new key does not exist.
+    pub async fn rename_nx<K: ToSingleRedisArg + Send + Sync, N: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        new_key: N,
+    ) -> AppResult<bool> {
+        let mut conn = self.redis().await?;
+        conn.rename_nx(key, new_key).await.into_app_result()
+    }
+
+    /// Unlink one or more keys (non-blocking DEL).
+    pub async fn unlink<K: ToRedisArgs + Send + Sync>(&self, key: K) -> AppResult<usize> {
+        let mut conn = self.redis().await?;
+        conn.unlink(key).await.into_app_result()
+    }
+
+    /// Determine if a key exists.
+    pub async fn exists<K: ToRedisArgs + Send + Sync>(&self, key: K) -> AppResult<bool> {
+        let mut conn = self.redis().await?;
+        conn.exists(key).await.into_app_result()
+    }
+
+    /// Set a key's time to live in seconds.
+    pub async fn expire<K: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        seconds: i64,
+    ) -> AppResult<bool> {
+        let mut conn = self.redis().await?;
+        conn.expire(key, seconds).await.into_app_result()
+    }
+
+    /// Set the expiration for a key as a UNIX timestamp.
+    pub async fn expire_at<K: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        ts: i64,
+    ) -> AppResult<bool> {
+        let mut conn = self.redis().await?;
+        conn.expire_at(key, ts).await.into_app_result()
+    }
+
+    /// Set a key's time to live in milliseconds.
+    pub async fn pexpire<K: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        ms: i64,
+    ) -> AppResult<bool> {
+        let mut conn = self.redis().await?;
+        conn.pexpire(key, ms).await.into_app_result()
+    }
+
+    /// Remove the expiration from a key.
+    pub async fn persist<K: ToSingleRedisArg + Send + Sync>(&self, key: K) -> AppResult<bool> {
+        let mut conn = self.redis().await?;
+        conn.persist(key).await.into_app_result()
+    }
+
+    /// Get the time to live for a key in seconds.
+    pub async fn ttl<K: ToSingleRedisArg + Send + Sync>(&self, key: K) -> AppResult<i64> {
+        let mut conn = self.redis().await?;
+        conn.ttl(key).await.into_app_result()
+    }
+
+    /// Get the time to live for a key in milliseconds.
+    pub async fn pttl<K: ToSingleRedisArg + Send + Sync>(&self, key: K) -> AppResult<i64> {
+        let mut conn = self.redis().await?;
+        conn.pttl(key).await.into_app_result()
+    }
+
+    /// Get the length of the value stored in a key.
+    pub async fn strlen<K: ToSingleRedisArg + Send + Sync>(&self, key: K) -> AppResult<usize> {
+        let mut conn = self.redis().await?;
+        conn.strlen(key).await.into_app_result()
+    }
+
+    // Hash Operations
+
+    /// Gets a single field from a hash.
+    pub async fn hget<K: ToSingleRedisArg + Send + Sync, F: ToSingleRedisArg + Send + Sync, V: FromRedisValue>(
+        &self,
+        key: K,
+        field: F,
+    ) -> AppResult<Option<V>> {
+        let mut conn = self.redis().await?;
+        conn.hget(key, field).await.into_app_result()
+    }
+
+    /// Gets multiple fields from a hash.
+    pub async fn hmget<K: ToSingleRedisArg + Send + Sync, F: ToRedisArgs + Send + Sync, V: FromRedisValue>(
+        &self,
+        key: K,
+        fields: F,
+    ) -> AppResult<Vec<V>> {
+        let mut conn = self.redis().await?;
+        conn.hmget(key, fields).await.into_app_result()
+    }
+
+    /// Deletes a single field from a hash.
+    pub async fn hdel<K: ToSingleRedisArg + Send + Sync, F: ToRedisArgs + Send + Sync>(
+        &self,
+        key: K,
+        field: F,
+    ) -> AppResult<usize> {
+        let mut conn = self.redis().await?;
+        conn.hdel(key, field).await.into_app_result()
+    }
+
+    /// Sets a single field in a hash.
+    pub async fn hset<K: ToSingleRedisArg + Send + Sync, F: ToSingleRedisArg + Send + Sync, V: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        field: F,
+        value: V,
+    ) -> AppResult<usize> {
+        let mut conn = self.redis().await?;
+        conn.hset(key, field, value).await.into_app_result()
+    }
+
+    /// Sets a single field in a hash if it does not exist.
+    pub async fn hset_nx<K: ToSingleRedisArg + Send + Sync, F: ToSingleRedisArg + Send + Sync, V: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        field: F,
+        value: V,
+    ) -> AppResult<bool> {
+        let mut conn = self.redis().await?;
+        conn.hset_nx(key, field, value).await.into_app_result()
+    }
+
+    /// Checks if a field in a hash exists.
+    pub async fn hexists<K: ToSingleRedisArg + Send + Sync, F: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        field: F,
+    ) -> AppResult<bool> {
+        let mut conn = self.redis().await?;
+        conn.hexists(key, field).await.into_app_result()
+    }
+
+    /// Get all the keys in a hash.
+    pub async fn hkeys<K: ToSingleRedisArg + Send + Sync>(&self, key: K) -> AppResult<Vec<String>> {
+        let mut conn = self.redis().await?;
+        conn.hkeys(key).await.into_app_result()
+    }
+
+    /// Get all the values in a hash.
+    pub async fn hvals<K: ToSingleRedisArg + Send + Sync>(&self, key: K) -> AppResult<Vec<String>> {
+        let mut conn = self.redis().await?;
+        conn.hvals(key).await.into_app_result()
+    }
+
+    /// Get all the fields and values in a hash.
+    pub async fn hgetall<K: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+    ) -> AppResult<HashMap<String, String>> {
+        let mut conn = self.redis().await?;
+        conn.hgetall(key).await.into_app_result()
+    }
+
+    /// Get the length of a hash.
+    pub async fn hlen<K: ToSingleRedisArg + Send + Sync>(&self, key: K) -> AppResult<usize> {
+        let mut conn = self.redis().await?;
+        conn.hlen(key).await.into_app_result()
+    }
+
+    /// Increments a value in a hash.
+    pub async fn hincr<K: ToSingleRedisArg + Send + Sync, F: ToSingleRedisArg + Send + Sync, D: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        field: F,
+        delta: D,
+    ) -> AppResult<f64> {
+        let mut conn = self.redis().await?;
+        conn.hincr(key, field, delta).await.into_app_result()
+    }
+
+    // List Operations
+
+    /// Get the length of a list.
+    pub async fn llen<K: ToSingleRedisArg + Send + Sync>(&self, key: K) -> AppResult<usize> {
+        let mut conn = self.redis().await?;
+        conn.llen(key).await.into_app_result()
+    }
+
+    /// Get an element from a list by its index.
+    pub async fn lindex<K: ToSingleRedisArg + Send + Sync, V: FromRedisValue>(
+        &self,
+        key: K,
+        index: isize,
+    ) -> AppResult<Option<V>> {
+        let mut conn = self.redis().await?;
+        conn.lindex(key, index).await.into_app_result()
+    }
+
+    /// Insert an element before another element in a list.
+    pub async fn linsert_before<
+        K: ToSingleRedisArg + Send + Sync,
+        P: ToSingleRedisArg + Send + Sync,
+        V: ToSingleRedisArg + Send + Sync,
+    >(
+        &self,
+        key: K,
+        pivot: P,
+        value: V,
+    ) -> AppResult<isize> {
+        let mut conn = self.redis().await?;
+        conn.linsert_before(key, pivot, value).await.into_app_result()
+    }
+
+    /// Insert an element after another element in a list.
+    pub async fn linsert_after<
+        K: ToSingleRedisArg + Send + Sync,
+        P: ToSingleRedisArg + Send + Sync,
+        V: ToSingleRedisArg + Send + Sync,
+    >(
+        &self,
+        key: K,
+        pivot: P,
+        value: V,
+    ) -> AppResult<isize> {
+        let mut conn = self.redis().await?;
+        conn.linsert_after(key, pivot, value).await.into_app_result()
+    }
+
+    /// Insert all the specified values at the head of the list stored at key.
+    pub async fn lpush<K: ToSingleRedisArg + Send + Sync, V: ToRedisArgs + Send + Sync>(
+        &self,
+        key: K,
+        value: V,
+    ) -> AppResult<usize> {
+        let mut conn = self.redis().await?;
+        conn.lpush(key, value).await.into_app_result()
+    }
+
+    /// Trim an existing list so that it will contain only the specified range of elements.
+    pub async fn ltrim<K: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        start: isize,
+        stop: isize,
+    ) -> AppResult<()> {
+        let mut conn = self.redis().await?;
+        conn.ltrim(key, start, stop).await.into_app_result()
+    }
+
+    /// Set the list element at index to value.
+    pub async fn lset<K: ToSingleRedisArg + Send + Sync, V: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        index: isize,
+        value: V,
+    ) -> AppResult<()> {
+        let mut conn = self.redis().await?;
+        conn.lset(key, index, value).await.into_app_result()
+    }
+
+    // Set Operations
+
+    /// Get the number of members in a set.
+    pub async fn scard<K: ToSingleRedisArg + Send + Sync>(&self, key: K) -> AppResult<usize> {
+        let mut conn = self.redis().await?;
+        conn.scard(key).await.into_app_result()
+    }
+
+    /// Determine if a given value is a member of a set.
+    pub async fn sismember<K: ToSingleRedisArg + Send + Sync, M: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        member: M,
+    ) -> AppResult<bool> {
+        let mut conn = self.redis().await?;
+        conn.sismember(key, member).await.into_app_result()
+    }
+
+    /// Get all the members in a set.
+    pub async fn smembers<K: ToSingleRedisArg + Send + Sync>(&self, key: K) -> AppResult<Vec<String>> {
+        let mut conn = self.redis().await?;
+        conn.smembers(key).await.into_app_result()
+    }
+
+    /// Remove one or more members from a set.
+    pub async fn srem<K: ToSingleRedisArg + Send + Sync, M: ToRedisArgs + Send + Sync>(
+        &self,
+        key: K,
+        member: M,
+    ) -> AppResult<usize> {
+        let mut conn = self.redis().await?;
+        conn.srem(key, member).await.into_app_result()
+    }
+
+    /// Get one random member from a set.
+    pub async fn srandmember<K: ToSingleRedisArg + Send + Sync, V: FromRedisValue>(
+        &self,
+        key: K,
+    ) -> AppResult<Option<V>> {
+        let mut conn = self.redis().await?;
+        conn.srandmember(key).await.into_app_result()
+    }
+
+    // Sorted Set Operations
+
+    /// Get the number of members in a sorted set.
+    pub async fn zcard<K: ToSingleRedisArg + Send + Sync>(&self, key: K) -> AppResult<usize> {
+        let mut conn = self.redis().await?;
+        conn.zcard(key).await.into_app_result()
+    }
+
+    /// Count the members in a sorted set with scores within the given values.
+    pub async fn zcount<
+        K: ToSingleRedisArg + Send + Sync,
+        M: ToSingleRedisArg + Send + Sync,
+        MM: ToSingleRedisArg + Send + Sync,
+    >(
+        &self,
+        key: K,
+        min: M,
+        max: MM,
+    ) -> AppResult<usize> {
+        let mut conn = self.redis().await?;
+        conn.zcount(key, min, max).await.into_app_result()
+    }
+
+    /// Increments the member in a sorted set at key by delta.
+    pub async fn zincr<
+        K: ToSingleRedisArg + Send + Sync,
+        M: ToSingleRedisArg + Send + Sync,
+        D: ToSingleRedisArg + Send + Sync,
+    >(
+        &self,
+        key: K,
+        member: M,
+        delta: D,
+    ) -> AppResult<f64> {
+        let mut conn = self.redis().await?;
+        conn.zincr(key, member, delta).await.into_app_result()
+    }
+
+    /// Get the score associated with the given member in a sorted set.
+    pub async fn zscore<K: ToSingleRedisArg + Send + Sync, M: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        member: M,
+    ) -> AppResult<Option<f64>> {
+        let mut conn = self.redis().await?;
+        conn.zscore(key, member).await.into_app_result()
+    }
+
+    /// Determine the index of a member in a sorted set.
+    pub async fn zrank<K: ToSingleRedisArg + Send + Sync, M: ToSingleRedisArg + Send + Sync>(
+        &self,
+        key: K,
+        member: M,
+    ) -> AppResult<Option<usize>> {
+        let mut conn = self.redis().await?;
+        conn.zrank(key, member).await.into_app_result()
+    }
+
+    /// Remove one or more members from a sorted set.
+    pub async fn zrem<K: ToSingleRedisArg + Send + Sync, M: ToRedisArgs + Send + Sync>(
+        &self,
+        key: K,
+        members: M,
+    ) -> AppResult<usize> {
+        let mut conn = self.redis().await?;
+        conn.zrem(key, members).await.into_app_result()
+    }
+
+    // Server Operations
+
+    /// Sends a ping to the server.
+    pub async fn ping(&self) -> AppResult<String> {
+        let mut conn = self.redis().await?;
+        conn.ping().await.into_app_result()
+    }
+
+    /// Returns the number of keys in the currently selected database.
+    pub async fn dbsize(&self) -> AppResult<usize> {
+        let mut conn = self.redis().await?;
+        redis::cmd("DBSIZE")
+            .query_async(&mut *conn)
+            .await
+            .into_app_result()
     }
 }

--- a/foxtive/src/results/app_result.rs
+++ b/foxtive/src/results/app_result.rs
@@ -20,6 +20,13 @@ impl<T: Serialize> IntoEmptyJson for AppResult<T> {
     }
 }
 
+#[cfg(feature = "rabbitmq")]
+impl<T> IntoAppResult<T> for crate::rabbitmq::RmqResult<T> {
+    fn into_app_result(self) -> AppResult<T> {
+        self.map_err(crate::Error::from)
+    }
+}
+
 #[cfg(feature = "database")]
 impl<T> IntoAppResult<T> for QueryResult<T> {
     fn into_app_result(self) -> AppResult<T> {


### PR DESCRIPTION
* feat(redis): use redis crate's AsyncCommands trait methods for type-safe API stability instead of raw commands
* feat(redis): add string operations: getset, getrange, setrange, append, incr, decr, set_ex, pset_ex, set_nx, get_del, rename, rename_nx, unlink, strlen
* feat(redis): add hash operations: hget, hmget, hdel, hset, hset_nx, hexists, hkeys, hvals, hgetall, hlen, hincr
* feat(redis): add list operations: llen, lindex, linsert_before, linsert_after, lpush, ltrim, lset
* feat(redis): add set operations: scard, sismember, smembers, srem, srandmember
* feat(redis): add sorted set operations: zcard, zcount, zincr, zscore, zrank, zrem
* feat(redis): add key operations: exists, expire, expire_at, pexpire, persist, ttl, pttl
* feat(redis): add server operations: ping, dbsize
* refactor(redis): ensure API stability by using typed AsyncCommands trait methods to prevent breakage on redis crate updates